### PR TITLE
Add missing protocol to href

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -348,7 +348,7 @@
 
               <li class="contributors__item">
                 <a
-                  href="github.com/BenJanecke"
+                  href="https://github.com/BenJanecke"
                   target="_blank"
                   class="contributors__link"
                   title="Ben Janecke"


### PR DESCRIPTION
Saw this was causing a 404 🙂 